### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,3 +16,6 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+
+[compat]
+CImGui = "~1.82"


### PR DESCRIPTION
CImGui major/minor versions follow upstream ImGui, so minor version updates may be breaking. This only allows patch updates.

(making the PR because there's a new breaking release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0)